### PR TITLE
Refina estilo oscuro con acentos blancos y efectos difuminados

### DIFF
--- a/src/components/Projectcard.jsx
+++ b/src/components/Projectcard.jsx
@@ -9,7 +9,7 @@ const ProjectCard = ({
     
 }) => {
     return (
-        <div className="bg-neutral-900 text-white shadow-lg rounded-lg overflow-hidden flex flex-col h-full border border-gray-700 hover:border-green-400 transition-all hover:scale-105">
+        <div className="bg-white/5 backdrop-blur-md text-white shadow-lg rounded-lg overflow-hidden flex flex-col h-full border border-white/15 hover:border-white/50 transition-all hover:scale-105">
             
             {image ? (
                 <div className="w-full aspect-video bg-gray-800">
@@ -39,7 +39,7 @@ const ProjectCard = ({
                             {technologies.map((tech, index) => (
                                 <span
                                     key={index}
-                                    className="px-3 py-1 bg-emerald-900 rounded-full text-sm text-green-300 hover:scale-110 transition-all cursor-pointer"
+                                    className="px-3 py-1 bg-white/10 border border-white/20 rounded-full text-sm text-gray-200 hover:scale-110 transition-all cursor-pointer"
                                 >
                                     {tech}
                                 </span>
@@ -74,7 +74,7 @@ const ProjectCard = ({
                             href={vercelLink}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="flex items-center gap-2 px-4 py-2 bg-blue-600 rounded-lg hover:bg-blue-500 transition-all hover:scale-105"
+                            className="flex items-center gap-2 px-4 py-2 bg-white text-black rounded-lg hover:bg-gray-200 transition-all hover:scale-105"
                         >
                             <svg
                                 xmlns="http://www.w3.org/2000/svg"

--- a/src/components/TechSlider.jsx
+++ b/src/components/TechSlider.jsx
@@ -3,15 +3,15 @@ import { FaHtml5, FaCss3Alt, FaJsSquare, FaReact, FaNodeJs, FaPython, FaGitAlt }
 import { SiTypescript, SiPostgresql } from "react-icons/si";
 
 const techIcons = [
-    { icon: <FaHtml5 className="text-orange-500" />, name: "HTML" },
-    { icon: <FaCss3Alt className="text-blue-500" />, name: "CSS" },
-    { icon: <FaJsSquare className="text-yellow-400" />, name: "JavaScript" },
-    { icon: <FaReact className="text-cyan-400" />, name: "React" },
-    { icon: <FaNodeJs className="text-green-500" />, name: "Node.js" },
-    { icon: <FaPython className="text-blue-300" />, name: "Python" },
-    { icon: <SiTypescript className="text-blue-600" />, name: "TypeScript" },
-    { icon: <SiPostgresql className="text-indigo-500" />, name: "PostgreSQL" },
-    { icon: <FaGitAlt className="text-orange-600" />, name: "Git" },
+    { icon: <FaHtml5 className="text-white" />, name: "HTML" },
+    { icon: <FaCss3Alt className="text-gray-300" />, name: "CSS" },
+    { icon: <FaJsSquare className="text-gray-200" />, name: "JavaScript" },
+    { icon: <FaReact className="text-white" />, name: "React" },
+    { icon: <FaNodeJs className="text-gray-300" />, name: "Node.js" },
+    { icon: <FaPython className="text-gray-200" />, name: "Python" },
+    { icon: <SiTypescript className="text-white" />, name: "TypeScript" },
+    { icon: <SiPostgresql className="text-gray-300" />, name: "PostgreSQL" },
+    { icon: <FaGitAlt className="text-gray-200" />, name: "Git" },
 ];
 
 export const TechSlider = () => {

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -12,7 +12,7 @@ const About = () => {
                 {/* Foto */}
                 <div className="relative w-60 md:w-200 flex items-center justify-center ">
                     {/* Fondo difuminado */}
-                    <div className="absolute inset-0 bg-green-400 rounded-full blur-3xl opacity-20 z-0" />
+                    <div className="absolute inset-0 bg-white rounded-full blur-3xl opacity-20 z-0" />
 
                     {/* Imagen encima */}
                     <img
@@ -26,7 +26,7 @@ const About = () => {
                 {/* Texto */}
                 <div className="text-center md:text-left">
                     <h2 className="text-2xl md:text-3xl font-bold">
-                        <span className="text-green-400">¡Hola!, soy David Garzón</span>
+                        <span className="text-white">¡Hola!, soy David Garzón</span>
                     </h2>
                     <h1 className="text-4xl md:text-6xl font-bold mt-2">
                         Desarrollador Fullstack Junior
@@ -48,7 +48,7 @@ const About = () => {
                             href="https://github.com/DavidGarzonDev"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="p-3 bg-gray-100 rounded-2xl hover:bg-gray-300 transition-all transform hover:scale-110"
+                            className="p-3 bg-white/10 border border-white/20 rounded-2xl hover:bg-white/20 transition-all transform hover:scale-110 backdrop-blur-md"
                         >
                             <img
                                 src={GithubIcon}
@@ -60,7 +60,7 @@ const About = () => {
                             href="https://www.linkedin.com/in/davidgarzondev/"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="p-3 bg-blue-600 rounded-2xl hover:bg-blue-500 transition-all transform hover:scale-110"
+                            className="p-3 bg-white/10 border border-white/20 rounded-2xl hover:bg-white/20 transition-all transform hover:scale-110 backdrop-blur-md"
                         >
                             <img
                                 src={LinkedinIcon}
@@ -72,7 +72,7 @@ const About = () => {
                             href="/Cv/cv-h.pdf"
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="p-3 bg-green-500 hover:bg-green-600 transition-all transform hover:scale-110 flex items-center justify-center rounded-full"
+                            className="p-3 bg-white text-black hover:bg-gray-200 transition-all transform hover:scale-110 flex items-center justify-center rounded-full"
                         >
                             <img src= "/Cv/cv.png" alt="Descargar CV" className="w-8 h-8 md:w-10 md:h-10" />
                                 

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -76,10 +76,10 @@ const Contact = () => {
 
     return (
         <section id="contact" className="max-w-2xl mx-auto py-12 px-4 sm:px-6 lg:px-8">
-            <h2 className="text-3xl font-bold text-center text-green-500 mb-8">Contáctame</h2>
+            <h2 className="text-3xl font-bold text-center text-white mb-8">Contáctame</h2>
             
             {sent && (
-                <div className="mb-6 p-4 bg-green-100 border border-green-400 text-green-700 rounded">
+                <div className="mb-6 p-4 bg-white/10 border border-white/30 text-white rounded backdrop-blur-md">
                     ¡Mensaje enviado con éxito! Me pondré en contacto contigo pronto.
                 </div>
             )}
@@ -101,7 +101,7 @@ const Contact = () => {
                         name="name"
                         value={formData.name}
                         onChange={handleChange}
-                        className={`w-full px-4 py-2 rounded-lg border ${errors.name ? 'border-red-500' : 'border-gray-600'} bg-gray-700 text-white focus:ring-2 focus:ring-green-500 focus:border-transparent`}
+                        className={`w-full px-4 py-2 rounded-lg border ${errors.name ? 'border-red-500' : 'border-white/20'} bg-white/10 text-white focus:ring-2 focus:ring-white focus:border-transparent backdrop-blur-md`}
                         placeholder="Tu nombre completo"
                     />
                     {errors.name && <p className="mt-1 text-sm text-red-400">{errors.name}</p>}
@@ -117,7 +117,7 @@ const Contact = () => {
                         name="email"
                         value={formData.email}
                         onChange={handleChange}
-                        className={`w-full px-4 py-2 rounded-lg border ${errors.email ? 'border-red-500' : 'border-gray-600'} bg-gray-700 text-white focus:ring-2 focus:ring-green-500 focus:border-transparent`}
+                        className={`w-full px-4 py-2 rounded-lg border ${errors.email ? 'border-red-500' : 'border-white/20'} bg-white/10 text-white focus:ring-2 focus:ring-white focus:border-transparent backdrop-blur-md`}
                         placeholder="tu@email.com"
                     />
                     {errors.email && <p className="mt-1 text-sm text-red-400">{errors.email}</p>}
@@ -133,7 +133,7 @@ const Contact = () => {
                         rows="5"
                         value={formData.message}
                         onChange={handleChange}
-                        className={`w-full px-4 py-2 rounded-lg border ${errors.message ? 'border-red-500' : 'border-gray-600'} bg-gray-700 text-white focus:ring-2 focus:ring-green-500 focus:border-transparent`}
+                        className={`w-full px-4 py-2 rounded-lg border ${errors.message ? 'border-red-500' : 'border-white/20'} bg-white/10 text-white focus:ring-2 focus:ring-white focus:border-transparent backdrop-blur-md`}
                         placeholder="Escribe tu mensaje aquí (mínimo 10 caracteres)..."
                     ></textarea>
                     {errors.message && <p className="mt-1 text-sm text-red-400">{errors.message}</p>}
@@ -143,7 +143,7 @@ const Contact = () => {
                     <button
                         type="submit"
                         disabled={isSubmitting}
-                        className={`w-full py-3 px-4 bg-green-600 hover:bg-green-700 text-white font-medium rounded-lg transition duration-200 ${isSubmitting ? 'opacity-70 cursor-not-allowed' : ''}`}
+                        className={`w-full py-3 px-4 bg-white hover:bg-gray-200 text-black font-medium rounded-lg transition duration-200 ${isSubmitting ? 'opacity-70 cursor-not-allowed' : ''}`}
                     >
                         {isSubmitting ? (
                             <span className="flex items-center justify-center">

--- a/src/pages/Header.jsx
+++ b/src/pages/Header.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Header = () => {
     return (
-        <header className="fixed top-0 left-0 w-full bg-transparent backdrop-blur-md z-50 py-0 shadow-sm ">
+        <header className="fixed top-0 left-0 w-full bg-black/20 backdrop-blur-xl z-50 py-0 border-b border-white/10">
             <nav className="w-full">
                 <ul className="flex justify-center space-x-0 md:space-x-15 w-full p-2">
                     {[
@@ -14,7 +14,7 @@ const Header = () => {
                             <a
                                 href={`#${item.id}`}
                                 className="relative text-gray-300 hover:text-white text-xl font-semibold transition-colors duration-300
-                    after:content-[''] after:absolute after:left-0 after:-bottom-1 after:w-0 after:h-1 after:bg-green-400 
+                    after:content-[''] after:absolute after:left-0 after:-bottom-1 after:w-0 after:h-1 after:bg-white 
                     after:transition-all after:duration-500 hover:after:w-full"
                             >
                                 {item.text}

--- a/src/pages/Projects.jsx
+++ b/src/pages/Projects.jsx
@@ -5,7 +5,7 @@ import TuRifa from "../assets/rifa.png";
 
 const Projects = () => {
     return (
-        <main className="min-h-screen bg-gradient-to-b  flex flex-col items-center py-16">
+        <main className="min-h-screen flex flex-col items-center py-16">
             {/* Título */}
             <h2 className="text-4xl md:text-5xl font-bold mb-12 text-center">
                 Mis Proyectos

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -18,8 +18,22 @@ html {
 }
 
 body {
-  background: #0D0D0D;
+  background: radial-gradient(circle at 15% 20%, rgba(255, 255, 255, 0.12), transparent 35%),
+    radial-gradient(circle at 85% 0%, rgba(255, 255, 255, 0.08), transparent 30%),
+    #050505;
   color: white;
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: radial-gradient(circle at 30% 70%, rgba(255, 255, 255, 0.1), transparent 40%),
+    radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.06), transparent 35%);
+  filter: blur(80px);
+  pointer-events: none;
+  z-index: -1;
 }
 
 nav ul {
@@ -60,8 +74,8 @@ nav ul li a:hover {
   
 }
 ::selection {
-  background-color: #22c55e; /* Tailwind: green-500 */
-  color: white; /* color del texto seleccionado */
+  background-color: #f5f5f5;
+  color: #050505;
 }
 
 @keyframes slide {


### PR DESCRIPTION
### Motivation
- Implementar un diseño solicitado de "fondo negro con toques blancos y difuminado" para lograr una estética nocturna más elegante y uniforme.
- Sustituir acentos verdes/azules por una paleta monocromática (blancos y grises) para coherencia visual y mejor contraste sobre el fondo oscuro.
- Mantener la estructura y funcionalidad existente del portafolio sin alterar la lógica de los componentes.

### Description
- Actualicé la hoja de estilos global en `src/styles/index.css` para usar un fondo negro profundo con capas de halos blancos difuminados y un pseudo-elemento `body::before` con `filter: blur` para el efecto glow.
- Ajusté la cabecera en `src/pages/Header.jsx` para usar un estilo glass (`bg-black/20`, `backdrop-blur-xl`) y cambié el subrayado activo a blanco para consistencia cromática.
- Rediseñé la sección de presentación en `src/pages/About.jsx` (glow de la foto a blanco, textos y botones sociales translúcidos en blanco/gris) y eliminé los acentos verdes en textos clave.
- Modifiqué las tarjetas de proyecto y chips en `src/components/Projectcard.jsx` para usar un fondo glass (`bg-white/5`, `backdrop-blur-md`) y tonos blancos en las etiquetas y botones; también actualicé los estilos del botón de demo a fondo blanco.
- Cambié la paleta de iconos en `src/components/TechSlider.jsx` a blancos/grises para mantener la coherencia con el tema oscuro.
- Unifiqué los inputs, estados de éxito y el botón principal en `src/pages/Contact.jsx` hacia estilos translúcidos y botón blanco para contraste, y quité un gradiente previo en `src/pages/Projects.jsx` para que herede el nuevo fondo.

### Testing
- Ejecuté la compilación de producción con `npm run build` y la construcción finalizó correctamente sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e28c3fdd6c83319d7c6a40dbf8a767)